### PR TITLE
fix worker bug when downloading multiple files successively.

### DIFF
--- a/src/download-progress.android.ts
+++ b/src/download-progress.android.ts
@@ -1,14 +1,6 @@
 import * as application from "tns-core-modules/application";
 import * as fs from "tns-core-modules/file-system";
 
-let worker: Worker;
-if (global["TNS_WEBPACK"]) {
-    const WorkerScript = require("nativescript-worker-loader!./android-worker.js");
-    worker = new WorkerScript();
-} else {
-    worker = new Worker("./android-worker.js");
-}
-
 export class DownloadProgress {
 
     private promiseResolve;
@@ -20,10 +12,18 @@ export class DownloadProgress {
     }
 
     public downloadFile(url: string, destinationFilePath?: string): Promise<fs.File> {
+        var worker;
+        if (global["TNS_WEBPACK"]) {
+            var WorkerScript = require("nativescript-worker-loader!./android-worker.js");
+            worker = new WorkerScript();
+        }
+        else {
+            worker = new Worker("./android-worker.js");
+        }
         return new Promise<fs.File>((resolve, reject) => {
             this.promiseResolve = resolve;
             this.promiseReject = reject;
-            //var worker = new Worker('./android-worker.js');
+
             worker.postMessage({ url: url, destinationFilePath: destinationFilePath });
             worker.onmessage = (msg:any)=> {
                 if(msg.data.progress) {


### PR DESCRIPTION
Hi , we encountered issues when trying to download multiple files successively.
this was the solution for us we did the require inside the download function.
ps:  this solution worked for both builds using and without using webpack.

### Which platform(s) does your issue occur on?
- Android
- on device.

### Please, provide the following version numbers that your issue occurs with:

- CLI: 3.4.3
- Cross-platform modules: 3.4.0
- Runtime(s): tns-android": "version": "3.4.1"
- Plugin(s): 1.0.9
### Please, tell us how to recreate the issue in as much detail as possible. 
download a file then download another one.
